### PR TITLE
solved but "Error:Loading initial props cancelled"

### DIFF
--- a/src/firebase/listsContext.tsx
+++ b/src/firebase/listsContext.tsx
@@ -57,7 +57,6 @@ export const ListsContextProvider = ({ children }: { children: ReactNode }) => {
               listsnapshot.push(doc.data());
             });
             if (!snapshot.size) {
-              console.log("No lists found for this user");
               addDoc(listsRef, createListData("my first list", user));
             }
             setOwnedLists(listsnapshot);

--- a/src/pages/lists/index.tsx
+++ b/src/pages/lists/index.tsx
@@ -11,7 +11,7 @@ const App: NextPage = () => {
   if (error) return <Error msg={error?.message} />;
   else if (loading) return <Loading />;
   else if (lists) {
-    router.push(`/lists/${lists[0].ref.id}`);
+    router.push(`/lists/${lists[0]?.ref.id}`);
   }
   return null;
 };


### PR DESCRIPTION
The bug breaking the page after initially loading /lists is solved, but there is still a `Error: Loading initial props cancelled`. This is OK for now, just under the hood, not causing any problems. This occurs because the `router.push` to the newly created list happens before the listContext finishes receiving the new snapshot. Probably `lists` is already updated instantly from cache so it becomes `!= null`  before snapshot results are in.